### PR TITLE
Feat/improve input check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='ViralFlow',
-      version='1.2.0',
+      version='1.3.0',
       description='''
       Workflows for viral genome Assembly at FioCruz/IAM
       ''',

--- a/versions/README.md
+++ b/versions/README.md
@@ -1,4 +1,4 @@
-## Versions of tools used in ViralFlow 1.1.1
+## Versions of tools used in ViralFlow 1.3.0
 
 |tool|version|
 |---|---|

--- a/vfnext/workflows/step0-input-handling.nf
+++ b/vfnext/workflows/step0-input-handling.nf
@@ -199,19 +199,13 @@ workflow processInputs {
     }
 
     // get reads
-    reads_channel_fqgz = channel.fromFilePairs("${params.inDir}/*_R{1,2}*.fq.gz")
-    reads_channel_fagz = channel.fromFilePairs("${params.inDir}/*_R{1,2}*.fastq.gz")
-    reads_channel_raw = reads_channel_fagz.concat(reads_channel_fqgz)
+    reads_channel_raw = channel.fromFilePairs("${params.reads}/*_{R,r}{1,2}.f{q.gz,astq,astq.gz}",
+                                              checkIfExists: true)
     // remove empty fastqs
     reads_channel= reads_channel_raw.filter(it -> (it[1][0].size()>0) && (it[1][1].size()>0))
     // raise warning if there is any empty file
     reads_channel_raw.filter(it -> (it[1][0].size()==0) && (it[1][1].size()==0))
         | view(it -> log.warn("Excluding ${it[0]} fastq files due to 0 bytes size)"))
-
-    if (reads_channel.count()==0){
-      log.error("No fastq files found. Be sure your fastq can be found by '*_R{1,2}*.fq.gz'(or fasta.gz) wildcard.")
-      exit 1
-    }
     // be sure a reference fasta and a reference gff was obtained
     assert !(reference_fa == null) && !(reference_gff == null)
 

--- a/vfnext/workflows/step0-input-handling.nf
+++ b/vfnext/workflows/step0-input-handling.nf
@@ -199,7 +199,7 @@ workflow processInputs {
     }
 
     // get reads
-    reads_channel_raw = channel.fromFilePairs("${params.inDir}/*_{R,r}{1,2}.f{q.gz,astq,astq.gz}",
+    reads_channel_raw = channel.fromFilePairs("${params.inDir}/*_{R,r}{1,2}.f{q,q.gz,astq,astq.gz}",
                                               checkIfExists: true)
     // remove empty fastqs
     reads_channel= reads_channel_raw.filter(it -> (it[1][0].size()>0) && (it[1][1].size()>0))

--- a/vfnext/workflows/step0-input-handling.nf
+++ b/vfnext/workflows/step0-input-handling.nf
@@ -199,7 +199,7 @@ workflow processInputs {
     }
 
     // get reads
-    reads_channel_raw = channel.fromFilePairs("${params.reads}/*_{R,r}{1,2}.f{q.gz,astq,astq.gz}",
+    reads_channel_raw = channel.fromFilePairs("${params.inDir}/*_{R,r}{1,2}.f{q.gz,astq,astq.gz}",
                                               checkIfExists: true)
     // remove empty fastqs
     reads_channel= reads_channel_raw.filter(it -> (it[1][0].size()>0) && (it[1][1].size()>0))

--- a/wrapper/viralflow
+++ b/wrapper/viralflow
@@ -8,7 +8,7 @@ from sys import exit
 
 __author__ = "Antonio Marinho da Silva Neto"
 __license__ = "GPL"
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __maintainer__ = "Antonio Marinho da Silva Neto"
 __email__ = "ad45@sanger.ac.uk"
 


### PR DESCRIPTION
## Changes

- Improve the input FASTQ wildcards to recognize both .fastq and .fq files, whether they are gzipped or not.
- Add a `checkIfExists` argument: if no files matching the wildcards are found in the input path, the workflow will exit and not attempt to execute the following steps (current behavior).

### Test changing the input directory to input_empty in the SARS-CoV-2 parameters.

![Screenshot 2024-10-18 at 08 12 19](https://github.com/user-attachments/assets/077b926d-fba5-4bb3-8a4a-621f91741997)
no task was executed
![Screenshot 2024-10-18 at 08 12 28](https://github.com/user-attachments/assets/9bf0ecc7-6963-4413-89c4-00352bcde5ec)

### Test gunzipping ART_2 files (I added the channel.view() method in the code to test to inspect the inputs being passed):

![Screenshot 2024-10-18 at 08 28 39](https://github.com/user-attachments/assets/5b682cdf-67c9-4337-b9c9-ba03a250a365)
